### PR TITLE
fix: Pass the entire settings object to jscodeshift

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@ import Runner from 'jscodeshift/dist/Runner.js';
 import util from './util';
 import chalk from 'chalk';
 
-function runTransforms({silent}, transforms, files) {
-	return Promise.mapSeries(transforms, transform => Runner.run(transform, files, {silent: silent}));
+function runTransforms(settings, transforms, files) {
+	return Promise.mapSeries(transforms, transform => Runner.run(transform, files, settings));
 }
 
 function cliArgs({pkg:{name,description,version}, libraryName},releases) {


### PR DESCRIPTION
The `jscodeshift` package has a `verbose` setting (which can be used to log errors), however, there was no way to pass a value to it because `runTransforms` was only grabbing `silent` from the object.  This change would allow any variable in that object to propagate all the way into `jscodeshift`.